### PR TITLE
Add a SOVERSION for proper versioning of the libnordlicht ABI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(Popt REQUIRED)
 include_directories(${CMAKE_BINARY_DIR}/src ${FFMPEG_INCLUDE_DIRS} ${FreeImage_INCLUDE_DIRS} ${POPT_INCLUDES})
 
 add_library(nordlicht SHARED src/common.c src/graphics.c src/nordlicht.c src/video.c)
+set_target_properties(nordlicht PROPERTIES SOVERSION 0)
 target_link_libraries(nordlicht ${FFMPEG_LIBRARIES} ${FreeImage_LIBRARIES} ${POPT_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 add_executable(nordlicht-bin src/main.c)


### PR DESCRIPTION
libnordlicht should have a clean versioning of the binary interface so it can be properly linked to other applications. The SOVERSION property can simply be increased if the ABI changes, and CMake takes care of all the rest.

I recommend reading [this FAQ](http://www.faqs.org/docs/Linux-HOWTO/Program-Library-HOWTO.html#AEN135) for a list of cases when the ABI version should (must?) be increased.
