### PR TITLE
add more detailed licensing information

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,10 @@ You can also help by packaging the software for your favorite operating system, 
 
 ## License: GPLv2+
 
+Copyright (C) 2014, Sebastian Morr and contributors.
+
 *nordlicht* is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
+
+*nordlicht* is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You can get a copy of the GNU General Public License at <http://www.gnu.org/licenses/>.


### PR DESCRIPTION
Debian is actually really accurate about the licensing information of upstream packages (which I regard as a feature), so a non-existing verbatim copyright line is [one of the reasons](https://lintian.debian.org/tags/copyright-without-copyright-notice.html) a package will be [rejected](https://ftp-master.debian.org/REJECT-FAQ.html). To fix this, I have added the GPL v2 in the file `LICENSE`, and extended `README.md` with a short copyright line, followed by the example text from GPL's section "How to Apply These Terms to Your New Programs". This should do it :-) 

Of course, as the upstream author, feel free to change everything to your needs, especially the Copyright line – I have taken my version from the nordlicht man page.
