### PR TITLE
Add Export specifier to API functions

### DIFF
--- a/nordlicht.c
+++ b/nordlicht.c
@@ -26,11 +26,11 @@ struct nordlicht {
     source *source;
 };
 
-size_t nordlicht_buffer_size(const nordlicht *n) {
+NORDLICHT_API size_t nordlicht_buffer_size(const nordlicht *n) {
     return n->width * n->height * 4;
 }
 
-nordlicht* nordlicht_init(const char *filename, const int width, const int height) {
+NORDLICHT_API nordlicht* nordlicht_init(const char *filename, const int width, const int height) {
     if (width < 1 || height < 1) {
         error("Dimensions must be positive (got %dx%d)", width, height);
         return NULL;
@@ -69,7 +69,7 @@ nordlicht* nordlicht_init(const char *filename, const int width, const int heigh
     return n;
 }
 
-void nordlicht_free(nordlicht *n) {
+NORDLICHT_API void nordlicht_free(nordlicht *n) {
     if (n->owns_data) {
         free(n->data);
     }
@@ -78,11 +78,11 @@ void nordlicht_free(nordlicht *n) {
     free(n);
 }
 
-const char *nordlicht_error() {
+NORDLICHT_API const char *nordlicht_error() {
     return get_error();
 }
 
-int nordlicht_set_start(nordlicht *n, const float start) {
+NORDLICHT_API int nordlicht_set_start(nordlicht *n, const float start) {
     if (! n->modifiable) {
         return -1;
     }
@@ -101,7 +101,7 @@ int nordlicht_set_start(nordlicht *n, const float start) {
     return 0;
 }
 
-int nordlicht_set_end(nordlicht *n, const float end) {
+NORDLICHT_API int nordlicht_set_end(nordlicht *n, const float end) {
     if (! n->modifiable) {
         return -1;
     }
@@ -120,7 +120,7 @@ int nordlicht_set_end(nordlicht *n, const float end) {
     return 0;
 }
 
-int nordlicht_set_style(nordlicht *n, const nordlicht_style *styles, const int num_tracks) {
+NORDLICHT_API int nordlicht_set_style(nordlicht *n, const nordlicht_style *styles, const int num_tracks) {
     if (! n->modifiable) {
         return -1;
     }
@@ -151,7 +151,7 @@ int nordlicht_set_style(nordlicht *n, const nordlicht_style *styles, const int n
     return 0;
 }
 
-int nordlicht_set_strategy(nordlicht *n, const nordlicht_strategy s) {
+NORDLICHT_API int nordlicht_set_strategy(nordlicht *n, const nordlicht_strategy s) {
     if (! n->modifiable) {
         return -1;
     }
@@ -162,7 +162,7 @@ int nordlicht_set_strategy(nordlicht *n, const nordlicht_strategy s) {
     return 0;
 }
 
-int nordlicht_generate(nordlicht *n) {
+NORDLICHT_API int nordlicht_generate(nordlicht *n) {
     n->modifiable = 0;
 
     source_build_keyframe_index(n->source, n->width);
@@ -254,7 +254,7 @@ int nordlicht_generate(nordlicht *n) {
     return 0;
 }
 
-int nordlicht_write(const nordlicht *n, const char *filename) {
+NORDLICHT_API int nordlicht_write(const nordlicht *n, const char *filename) {
     int code = 0;
 
     if (filename == NULL) {
@@ -296,15 +296,15 @@ int nordlicht_write(const nordlicht *n, const char *filename) {
     return code;
 }
 
-float nordlicht_progress(const nordlicht *n) {
+NORDLICHT_API float nordlicht_progress(const nordlicht *n) {
     return n->progress;
 }
 
-const unsigned char* nordlicht_buffer(const nordlicht *n) {
+NORDLICHT_API const unsigned char* nordlicht_buffer(const nordlicht *n) {
     return n->data;
 }
 
-int nordlicht_set_buffer(nordlicht *n, unsigned char *data) {
+NORDLICHT_API int nordlicht_set_buffer(nordlicht *n, unsigned char *data) {
     if (! n->modifiable) {
         return -1;
     }

--- a/nordlicht.h
+++ b/nordlicht.h
@@ -2,6 +2,29 @@
 #define INCLUDE_nordlicht_h__
 #include <stdlib.h> // for size_t
 
+
+#ifndef NORDLICHT_API
+#  ifdef _WIN32
+#     if defined(NORDLICHT_BUILD_SHARED) /* build dll */
+#         define NORDLICHT_API __declspec(dllexport)
+#     elif !defined(NORDLICHT_BUILD_STATIC) /* use dll */
+#         define NORDLICHT_API __declspec(dllimport)
+#     else /* static library */
+#         define NORDLICHT_API
+#     endif
+#  else
+#     if __GNUC__ >= 4
+#         define NORDLICHT_API __attribute__((visibility("default")))
+#     else
+#         define NORDLICHT_API
+#     endif
+#  endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct nordlicht nordlicht;
 
 typedef enum nordlicht_style {
@@ -20,51 +43,55 @@ typedef enum nordlicht_strategy {
 } nordlicht_strategy;
 
 // Returns a description of the last error, or NULL if the was no error.
-const char *nordlicht_error();
+NORDLICHT_API const char *nordlicht_error();
 
 // Allocate a new nordlicht of specific width and height, for a given video
 // file. When `live` is true, give a fast approximation before starting the
 // slow, exact generation. Use `nordlicht_free` to free the nordlicht again.
 // Returns NULL on errors.
-nordlicht* nordlicht_init(const char *filename, const int width, const int height);
+NORDLICHT_API nordlicht* nordlicht_init(const char *filename, const int width, const int height);
 
 // Free a nordlicht.
-void nordlicht_free(nordlicht *n);
+NORDLICHT_API void nordlicht_free(nordlicht *n);
 
 // Specify where to start the nordlicht, in percent between 0 and 1.
-int nordlicht_set_start(nordlicht *n, const float start);
+NORDLICHT_API int nordlicht_set_start(nordlicht *n, const float start);
 
 // Specify where to end the nordlicht, in percent between 0 and 1.
-int nordlicht_set_end(nordlicht *n, const float end);
+NORDLICHT_API int nordlicht_set_end(nordlicht *n, const float end);
 
 // Set the output style(s) of the nordlicht. Default is NORDLICHT_STYLE_HORIZONTAL.
 // Expects a pointer to an array of nordlicht_style-s of length `num_styles`.
 // Returns 0 on success.
-int nordlicht_set_style(nordlicht *n, const nordlicht_style *s, const int num_styles);
+NORDLICHT_API int nordlicht_set_style(nordlicht *n, const nordlicht_style *s, const int num_styles);
 
 // Set the generation strategy of the nordlicht. Default is NORDLICHT_STRATEGY_FAST.
 // Returns 0 on success. This function will be removed in the future.
-int nordlicht_set_strategy(nordlicht *n, const nordlicht_strategy s);
+NORDLICHT_API int nordlicht_set_strategy(nordlicht *n, const nordlicht_strategy s);
 
 // Returns a pointer to the nordlicht's internal buffer. You can use it to draw
 // the barcode while it is generated. The pixel format is 32-bit BGRA.
-const unsigned char* nordlicht_buffer(const nordlicht *n);
+NORDLICHT_API const unsigned char* nordlicht_buffer(const nordlicht *n);
 
 // Replace the internal nordlicht's internal buffer. The data pointer is owned
 // by the caller and must be freed after `nordlicht_free`. Returns 0 on success.
-int nordlicht_set_buffer(nordlicht *n, unsigned char *data);
+NORDLICHT_API int nordlicht_set_buffer(nordlicht *n, unsigned char *data);
 
 // Returns the size of this nordlicht's buffer in bytes.
-size_t nordlicht_buffer_size(const nordlicht *n);
+NORDLICHT_API size_t nordlicht_buffer_size(const nordlicht *n);
 
 // Generate the nordlicht. Calling this will freeze the nordlicht:
 // "set" functions will fail. Returns 0 on success.
-int nordlicht_generate(nordlicht *n);
+NORDLICHT_API int nordlicht_generate(nordlicht *n);
 
 // Returns a value between 0 and 1 indicating how much of the nordlicht is done.
-float nordlicht_progress(const nordlicht *n);
+NORDLICHT_API float nordlicht_progress(const nordlicht *n);
 
 // Write the nordlicht to a PNG file. Returns 0 on success.
-int nordlicht_write(const nordlicht *n, const char *filename);
+NORDLICHT_API int nordlicht_write(const nordlicht *n, const char *filename);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Hi!

Could you please merge that changes before the next release. It is required for MSVC to allow external linkage of your library.
Furether info can be found here:
http://lucumr.pocoo.org/2013/8/18/beautiful-native-libraries/