### PR TITLE
ffmpeg backwards compatibility and ffmpeg 3.0 deprecated functions

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -5,6 +5,13 @@
 #include <string.h>
 #include <libswscale/swscale.h>
 
+// Changes for ffmpeg 3.0
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57,24,0)
+#  include <libavutil/imgutils.h>
+#  define av_free_packet av_packet_unref
+#  define avpicture_get_size(fmt,w,h) av_image_get_buffer_size(fmt,w,h,1)
+#endif
+
 // PIX_FMT was renamed to AV_PIX_FMT on this version
 #if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(51,74,100)
 #  define AVPixelFormat PixelFormat

--- a/src/image.c
+++ b/src/image.c
@@ -5,11 +5,29 @@
 #include <string.h>
 #include <libswscale/swscale.h>
 
+// PIX_FMT was renamed to AV_PIX_FMT on this version
+#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(51,74,100)
+#  define AVPixelFormat PixelFormat
+#  define AV_PIX_FMT_RGB24 PIX_FMT_RGB24
+#  define AV_PIX_FMT_YUVJ420P PIX_FMT_YUVJ420P
+#  define AV_PIX_FMT_YUVJ422P PIX_FMT_YUVJ422P
+#  define AV_PIX_FMT_YUVJ440P PIX_FMT_YUVJ440P
+#  define AV_PIX_FMT_YUVJ444P PIX_FMT_YUVJ444P
+#  define AV_PIX_FMT_YUV420P  PIX_FMT_YUV420P
+#  define AV_PIX_FMT_YUV422P  PIX_FMT_YUV422P
+#  define AV_PIX_FMT_YUV440P  PIX_FMT_YUV440P
+#  define AV_PIX_FMT_YUV444P  PIX_FMT_YUV444P
+#endif
+
 #if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(52, 8, 0)
-#define av_frame_alloc  avcodec_alloc_frame
-#define av_frame_free av_freep
+#  define av_frame_alloc  avcodec_alloc_frame
+#  if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(54,59,100)
+#    define av_frame_free   av_freep
+#  else
+#    define av_frame_free   avcodec_free_frame
+#  endif
 void av_frame_get_buffer(AVFrame *frame, int magic) { avpicture_alloc((AVPicture *)frame, frame->format, frame->width, frame->height); }
-void av_frame_copy(AVFrame *dst, AVFrame *src) { memcpy(dst->data[0], src->data[0], sizeof(uint8_t)*avpicture_get_size(PIX_FMT_RGB24, dst->width, dst->height)); }
+void av_frame_copy(AVFrame *dst, AVFrame *src) { memcpy(dst->data[0], src->data[0], sizeof(uint8_t)*avpicture_get_size(AV_PIX_FMT_RGB24, dst->width, dst->height)); }
 #endif
 
 #define MAX_FILTER_SIZE 256
@@ -25,7 +43,7 @@ image *image_init(const int width, const int height) {
     i->frame = (AVFrame *) av_frame_alloc();
     i->frame->width = width;
     i->frame->height = height;
-    i->frame->format = PIX_FMT_RGB24; // best choice?
+    i->frame->format = AV_PIX_FMT_RGB24; // best choice?
     av_frame_get_buffer(i->frame, 16); // magic number?
     return i;
 }
@@ -240,7 +258,7 @@ int image_write_png(const image *i, const char *file_path) {
     encoder_context = avcodec_alloc_context3(encoder);
     encoder_context->width = i->frame->width;
     encoder_context->height = i->frame->height;
-    encoder_context->pix_fmt = PIX_FMT_RGB24;
+    encoder_context->pix_fmt = AV_PIX_FMT_RGB24;
     if (avcodec_open2(encoder_context, encoder, NULL) < 0) {
         error("Could not open output codec.");
         return -1;

--- a/src/source.c
+++ b/src/source.c
@@ -6,9 +6,27 @@
 #include <libavutil/avutil.h>
 #include <libswscale/swscale.h>
 
+// PIX_FMT was renamed to AV_PIX_FMT on this version
+#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(51,74,100)
+#  define AVPixelFormat PixelFormat
+#  define AV_PIX_FMT_RGB24 PIX_FMT_RGB24
+#  define AV_PIX_FMT_YUVJ420P PIX_FMT_YUVJ420P
+#  define AV_PIX_FMT_YUVJ422P PIX_FMT_YUVJ422P
+#  define AV_PIX_FMT_YUVJ440P PIX_FMT_YUVJ440P
+#  define AV_PIX_FMT_YUVJ444P PIX_FMT_YUVJ444P
+#  define AV_PIX_FMT_YUV420P  PIX_FMT_YUV420P
+#  define AV_PIX_FMT_YUV422P  PIX_FMT_YUV422P
+#  define AV_PIX_FMT_YUV440P  PIX_FMT_YUV440P
+#  define AV_PIX_FMT_YUV444P  PIX_FMT_YUV444P
+#endif
+
 #if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(52, 8, 0)
-#define av_frame_alloc  avcodec_alloc_frame
-#define av_frame_free av_freep
+#  define av_frame_alloc  avcodec_alloc_frame
+#  if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(54,59,100)
+#    define av_frame_free   av_freep
+#  else
+#    define av_frame_free   avcodec_free_frame
+#  endif
 #endif
 
 #define HEURISTIC_NUMBER_OF_FRAMES 1800 // how many frames will the heuristic look at?
@@ -251,13 +269,13 @@ source* source_init(const char *filename) {
         s->scaleframe = av_frame_alloc();
         s->scaleframe->width = s->video->frame->width;
         s->scaleframe->height = s->video->frame->height;
-        s->scaleframe->format = PIX_FMT_RGB24;
+        s->scaleframe->format = AV_PIX_FMT_RGB24;
 
-        s->buffer = (uint8_t *)av_malloc(sizeof(uint8_t)*avpicture_get_size(PIX_FMT_RGB24, s->scaleframe->width, s->scaleframe->height));
-        avpicture_fill((AVPicture *)s->scaleframe, s->buffer, PIX_FMT_RGB24, s->video->frame->width, s->video->frame->height);
+        s->buffer = (uint8_t *)av_malloc(sizeof(uint8_t)*avpicture_get_size(s->scaleframe->format, s->scaleframe->width, s->scaleframe->height));
+        avpicture_fill((AVPicture *)s->scaleframe, s->buffer, s->scaleframe->format, s->video->frame->width, s->video->frame->height);
 
         s->sws_context = sws_getCachedContext(NULL, s->video->frame->width, s->video->frame->height, s->video->frame->format,
-                s->scaleframe->width, s->scaleframe->height, PIX_FMT_RGB24, SWS_AREA, NULL, NULL, NULL);
+                s->scaleframe->width, s->scaleframe->height, s->scaleframe->format, SWS_AREA, NULL, NULL, NULL);
     }
 
     s->keyframes = NULL;


### PR DESCRIPTION
This also resolves building errors on my Arch x86_64 machine due to removed PIX_FMT.