### PR TITLE
Set time_base for png encoder instantiation

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -266,6 +266,8 @@ int image_write_png(const image *i, const char *file_path) {
     encoder_context->width = i->frame->width;
     encoder_context->height = i->frame->height;
     encoder_context->pix_fmt = AV_PIX_FMT_RGB24;
+    encoder_context->time_base.num = 1;
+    encoder_context->time_base.den = 1;
     if (avcodec_open2(encoder_context, encoder, NULL) < 0) {
         error("Could not open output codec.");
         return -1;


### PR DESCRIPTION
Fixes #62.

Apparently AVCodecContext::time_base must now be set for encoders, like
mentioned in the docs [1](https://ffmpeg.org/doxygen/3.1/structAVCodecContext.html#ab7bfeb9fa5840aac090e2b0bd0ef7589).  It does not say however which value should
be put for single-frame encoders, but a quick grep [2] on the lavc PNG
code does not result in a result, so I guess the PNG encoder simply
ignores this value.  However, avcodec_open2() tests if it is set and
will return -1 if it's unset.

[2]: grep time_base ~/tmp/ffmpeg-3.1.3/libavcodec/png*
